### PR TITLE
[#6] 네이버 통합검색어 트렌드 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,17 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.data:spring-data-envers'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+        implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+        implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+        implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/external/.gitignore
+++ b/external/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### application ###
+/src/main/resources/application-secret.yml

--- a/external/build.gradle
+++ b/external/build.gradle
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/external/src/main/java/com/trendreport/external/ExternalApplication.java
+++ b/external/src/main/java/com/trendreport/external/ExternalApplication.java
@@ -1,0 +1,13 @@
+package com.trendreport.external;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+
+@SpringBootApplication(exclude={DataSourceAutoConfiguration.class})
+public class ExternalApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ExternalApplication.class,args);
+    }
+}

--- a/external/src/main/java/com/trendreport/external/config/SecurityConfig.java
+++ b/external/src/main/java/com/trendreport/external/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.trendreport.external.config;
+
+import com.trendreport.external.security.JwtAuthenticationFilter;
+import com.trendreport.external.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig{
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){return new BCryptPasswordEncoder();}
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests((authorize) -> authorize
+                .requestMatchers( "/swagger-ui/**","/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated())
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class)
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        ;
+        return http.build();
+    }
+}

--- a/external/src/main/java/com/trendreport/external/config/SwaggerConfig.java
+++ b/external/src/main/java/com/trendreport/external/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.trendreport.external.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Example API Docs",
+        description = "Description",
+        version = "v1"
+    )
+)
+@Configuration
+public class SwaggerConfig {
+
+    private static final String BEARER_TOKEN_PREFIX = "Bearer";
+
+    @Bean
+    public OpenAPI openAPI() {
+        String securityJwtName = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityJwtName);
+        Components components = new Components()
+            .addSecuritySchemes(securityJwtName, new SecurityScheme()
+                .name(securityJwtName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(BEARER_TOKEN_PREFIX)
+                .bearerFormat(securityJwtName));
+
+        return new OpenAPI()
+            .addSecurityItem(securityRequirement)
+            .components(components);
+    }
+}

--- a/external/src/main/java/com/trendreport/external/config/WebClientConfig.java
+++ b/external/src/main/java/com/trendreport/external/config/WebClientConfig.java
@@ -12,9 +12,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class WebClientConfig {
 
-    private final String BASE_URL = "https://openapi.naver.com/v1/datalab";
     @Value("${naver.client-id}")
     private String CLIENT_ID;
+
     @Value("${naver.client-secret}")
     private String CLIENT_SECRET;
 
@@ -28,7 +28,6 @@ public class WebClientConfig {
     @Bean
     public WebClient webClient(){
         return WebClient.builder()
-            .baseUrl((BASE_URL))
             .defaultHeaders(httpHeaders -> {
                 httpHeaders.add("X-Naver-Client-Id", CLIENT_ID);
                 httpHeaders.add("X-Naver-Client-Secret", CLIENT_SECRET);

--- a/external/src/main/java/com/trendreport/external/config/WebClientConfig.java
+++ b/external/src/main/java/com/trendreport/external/config/WebClientConfig.java
@@ -1,0 +1,39 @@
+package com.trendreport.external.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.ReactorResourceFactory;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+    private final String BASE_URL = "https://openapi.naver.com/v1/datalab";
+    @Value("${naver.client-id}")
+    private String CLIENT_ID;
+    @Value("${naver.client-secret}")
+    private String CLIENT_SECRET;
+
+    @Bean
+    public ReactorResourceFactory resourceFactory(){
+        ReactorResourceFactory factory = new ReactorResourceFactory();
+        factory.setUseGlobalResources(false);
+        return factory;
+    }
+
+    @Bean
+    public WebClient webClient(){
+        return WebClient.builder()
+            .baseUrl((BASE_URL))
+            .defaultHeaders(httpHeaders -> {
+                httpHeaders.add("X-Naver-Client-Id", CLIENT_ID);
+                httpHeaders.add("X-Naver-Client-Secret", CLIENT_SECRET);
+                httpHeaders.add(HttpHeaders.CONTENT_TYPE,"application/json");
+            })
+            .build();
+    }
+}

--- a/external/src/main/java/com/trendreport/external/controller/TrendController.java
+++ b/external/src/main/java/com/trendreport/external/controller/TrendController.java
@@ -1,0 +1,25 @@
+package com.trendreport.external.controller;
+
+import com.trendreport.external.dto.TrendReportForm;
+import com.trendreport.external.service.TrendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('USER')")
+@RequestMapping("/external")
+public class TrendController {
+
+    private final TrendService trendService;
+
+    @PostMapping()
+    public ResponseEntity<?> getTrendReport(@RequestBody TrendReportForm form){
+        return ResponseEntity.ok(trendService.getSearchTrend(trendService.createTrendDto(form)));
+    }
+}

--- a/external/src/main/java/com/trendreport/external/dto/Ages.java
+++ b/external/src/main/java/com/trendreport/external/dto/Ages.java
@@ -1,0 +1,26 @@
+package com.trendreport.external.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Ages {
+    RANGE_0_TO_12(1),
+    RANGE_13_TO_18(2),
+    RANGE_19_TO_24(3),
+    RANGE_25_TO_29(4),
+    RANGE_30_TO_34(5),
+    RANGE_35_TO_39(6),
+    RANGE_40_TO_44(7),
+    RANGE_45_TO_49(8),
+    RANGE_50_TO_54(9),
+    RANGE_55_TO_59(10),
+    RANGE_60_AND_ABOVE(11);
+
+    private final int value;
+
+    public String toString(){
+        return String.valueOf(this.getValue());
+    }
+}

--- a/external/src/main/java/com/trendreport/external/dto/Device.java
+++ b/external/src/main/java/com/trendreport/external/dto/Device.java
@@ -1,0 +1,11 @@
+package com.trendreport.external.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Device {
+
+    pc,mo
+}

--- a/external/src/main/java/com/trendreport/external/dto/Gender.java
+++ b/external/src/main/java/com/trendreport/external/dto/Gender.java
@@ -1,0 +1,10 @@
+package com.trendreport.external.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    m,f
+}

--- a/external/src/main/java/com/trendreport/external/dto/KeywordGroup.java
+++ b/external/src/main/java/com/trendreport/external/dto/KeywordGroup.java
@@ -1,0 +1,12 @@
+package com.trendreport.external.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class KeywordGroup {
+    private String groupName;
+    private List<String> keywords;
+}

--- a/external/src/main/java/com/trendreport/external/dto/ResultData.java
+++ b/external/src/main/java/com/trendreport/external/dto/ResultData.java
@@ -1,0 +1,11 @@
+package com.trendreport.external.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResultData {
+    private String period;
+    private String ratio;
+}

--- a/external/src/main/java/com/trendreport/external/dto/TimeUnit.java
+++ b/external/src/main/java/com/trendreport/external/dto/TimeUnit.java
@@ -1,0 +1,11 @@
+package com.trendreport.external.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TimeUnit {
+
+    date,week,month
+}

--- a/external/src/main/java/com/trendreport/external/dto/TrendDto.java
+++ b/external/src/main/java/com/trendreport/external/dto/TrendDto.java
@@ -1,0 +1,17 @@
+package com.trendreport.external.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TrendDto {
+    private String startDate;
+    private String endDate;
+    private String timeUnit;
+    private List<KeywordGroup> keywordGroups;
+    private String device;
+    private String gender;
+    private List<String> ages;
+}

--- a/external/src/main/java/com/trendreport/external/dto/TrendReportForm.java
+++ b/external/src/main/java/com/trendreport/external/dto/TrendReportForm.java
@@ -1,5 +1,7 @@
 package com.trendreport.external.dto;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +9,17 @@ import lombok.Getter;
 @Getter
 @Builder
 public class TrendReportForm {
-    private String timeUnit;
+    @Enumerated(EnumType.STRING)
+    private TimeUnit timeUnit;
+
     private List<KeywordGroup> keywordGroups;
+
+    @Enumerated(EnumType.STRING)
+    private Device device;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private List<Ages> ages;
 }

--- a/external/src/main/java/com/trendreport/external/dto/TrendReportForm.java
+++ b/external/src/main/java/com/trendreport/external/dto/TrendReportForm.java
@@ -1,0 +1,12 @@
+package com.trendreport.external.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TrendReportForm {
+    private String timeUnit;
+    private List<KeywordGroup> keywordGroups;
+}

--- a/external/src/main/java/com/trendreport/external/dto/TrendResponse.java
+++ b/external/src/main/java/com/trendreport/external/dto/TrendResponse.java
@@ -1,5 +1,6 @@
 package com.trendreport.external.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,8 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TrendResponse {
-    private String startDate;
-    private String endDate;
-    private String timeUnit;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private TimeUnit timeUnit;
     private List<TrendResponseResult> results;
 }

--- a/external/src/main/java/com/trendreport/external/dto/TrendResponse.java
+++ b/external/src/main/java/com/trendreport/external/dto/TrendResponse.java
@@ -1,0 +1,18 @@
+package com.trendreport.external.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrendResponse {
+    private String startDate;
+    private String endDate;
+    private String timeUnit;
+    private List<TrendResponseResult> results;
+}

--- a/external/src/main/java/com/trendreport/external/dto/TrendResponseResult.java
+++ b/external/src/main/java/com/trendreport/external/dto/TrendResponseResult.java
@@ -1,0 +1,13 @@
+package com.trendreport.external.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TrendResponseResult {
+    private String title;
+    private List<String> keywords;
+    private List<ResultData> data;
+}

--- a/external/src/main/java/com/trendreport/external/security/JwtAuthenticationFilter.java
+++ b/external/src/main/java/com/trendreport/external/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.trendreport.external.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilter {
+
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+        String token = resolveToken((HttpServletRequest) request);
+
+        if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)){
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request,response);
+    }
+
+    private String resolveToken(HttpServletRequest request){
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if((ObjectUtils.isEmpty(token) || token.startsWith(TOKEN_PREFIX)) && token != null){
+            return token.substring(TOKEN_PREFIX.length());
+        }
+        return "";
+    }
+}

--- a/external/src/main/java/com/trendreport/external/security/JwtAuthenticationFilter.java
+++ b/external/src/main/java/com/trendreport/external/security/JwtAuthenticationFilter.java
@@ -29,9 +29,12 @@ public class JwtAuthenticationFilter extends GenericFilter {
         String token = resolveToken((HttpServletRequest) request);
 
         if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)){
+
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
         chain.doFilter(request,response);
     }
 

--- a/external/src/main/java/com/trendreport/external/security/JwtTokenProvider.java
+++ b/external/src/main/java/com/trendreport/external/security/JwtTokenProvider.java
@@ -1,0 +1,73 @@
+package com.trendreport.external.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    @Value("${spring.jwt.secret}")
+    private String SECRETE_KEY;
+    private static final String KEY_ROLE = "role";
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(this.SECRETE_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        String email = claims.getSubject();
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(KEY_ROLE).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        return new UsernamePasswordAuthenticationToken(email,accessToken,authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(this.getSigningKey()).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(this.getSigningKey())
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/external/src/main/java/com/trendreport/external/service/TrendService.java
+++ b/external/src/main/java/com/trendreport/external/service/TrendService.java
@@ -1,0 +1,77 @@
+package com.trendreport.external.service;
+
+import com.trendreport.external.dto.KeywordGroup;
+import com.trendreport.external.dto.TrendDto;
+import com.trendreport.external.dto.TrendReportForm;
+import com.trendreport.external.dto.TrendResponse;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TrendService {
+
+    private final WebClient webClient;
+    private final ZonedDateTime kst = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+
+    public TrendResponse getSearchTrend(TrendDto trendDto){
+        return webClient.post()
+            .uri("/search")
+            .bodyValue(trendDto)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                throw new RuntimeException("4xx");
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+                throw new RuntimeException("5xx");
+            })
+            .bodyToMono(TrendResponse.class)
+            .block();
+    }
+
+    public TrendDto createTrendDto(TrendReportForm form){
+        String timeUnit = form.getTimeUnit();
+        List<KeywordGroup> keywordGroup = form.getKeywordGroups();
+
+        LocalDateTime now = kst.toLocalDateTime();
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String endDate = now.format(dateFormat);
+        String startDate = now.format(dateFormat);
+
+        //주간
+        if(timeUnit.equals("date")){
+            startDate = now.minusDays(7).format(dateFormat);
+        }
+
+        //월간
+        if(timeUnit.equals("week")){
+            startDate = now.minusWeeks(4).format(dateFormat);
+        }
+
+        //연간
+        if(timeUnit.equals("month")){
+            startDate = now.minusMonths(12).format(dateFormat);
+        }
+
+        return TrendDto.builder()
+            .startDate(startDate)
+            .endDate(endDate)
+            .timeUnit(timeUnit)
+            .keywordGroups(keywordGroup)
+            .device("pc")
+            .gender("m")
+            .ages(new ArrayList<>())
+            .build();
+    }
+
+}

--- a/external/src/main/java/com/trendreport/external/service/TrendService.java
+++ b/external/src/main/java/com/trendreport/external/service/TrendService.java
@@ -1,6 +1,8 @@
 package com.trendreport.external.service;
 
+import com.trendreport.external.dto.Ages;
 import com.trendreport.external.dto.KeywordGroup;
+import com.trendreport.external.dto.TimeUnit;
 import com.trendreport.external.dto.TrendDto;
 import com.trendreport.external.dto.TrendReportForm;
 import com.trendreport.external.dto.TrendResponse;
@@ -8,8 +10,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
@@ -24,9 +26,11 @@ public class TrendService {
     private final WebClient webClient;
     private final ZonedDateTime kst = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
 
+    private final String NAVER_SEARCH_URL = "https://openapi.naver.com/v1/datalab/search";
+
     public TrendResponse getSearchTrend(TrendDto trendDto){
         return webClient.post()
-            .uri("/search")
+            .uri(NAVER_SEARCH_URL)
             .bodyValue(trendDto)
             .retrieve()
             .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
@@ -40,7 +44,7 @@ public class TrendService {
     }
 
     public TrendDto createTrendDto(TrendReportForm form){
-        String timeUnit = form.getTimeUnit();
+        TimeUnit timeUnit = form.getTimeUnit();
         List<KeywordGroup> keywordGroup = form.getKeywordGroups();
 
         LocalDateTime now = kst.toLocalDateTime();
@@ -49,28 +53,28 @@ public class TrendService {
         String startDate = now.format(dateFormat);
 
         //주간
-        if(timeUnit.equals("date")){
+        if(timeUnit.toString().equals("date")){
             startDate = now.minusDays(7).format(dateFormat);
         }
 
         //월간
-        if(timeUnit.equals("week")){
+        if(timeUnit.toString().equals("week")){
             startDate = now.minusWeeks(4).format(dateFormat);
         }
 
         //연간
-        if(timeUnit.equals("month")){
+        if(timeUnit.toString().equals("month")){
             startDate = now.minusMonths(12).format(dateFormat);
         }
 
         return TrendDto.builder()
             .startDate(startDate)
             .endDate(endDate)
-            .timeUnit(timeUnit)
+            .timeUnit(timeUnit.toString())
             .keywordGroups(keywordGroup)
-            .device("pc")
-            .gender("m")
-            .ages(new ArrayList<>())
+            .device(form.getDevice().toString())
+            .gender(form.getGender().toString())
+            .ages(form.getAges().stream().map(Ages::toString).collect(Collectors.toList()))
             .build();
     }
 

--- a/external/src/main/resources/application.yml
+++ b/external/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+server:
+  port: 8081
+spring:
+  jwt:
+    secret: cc40a3791cf94e649344be45eb1292a2546sdf884d56sf63qwe8mfb
+  profiles:
+    include: secret

--- a/external/src/test/java/com/trendreport/external/service/TrendServiceTest.java
+++ b/external/src/test/java/com/trendreport/external/service/TrendServiceTest.java
@@ -1,0 +1,70 @@
+package com.trendreport.external.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.trendreport.external.dto.TrendDto;
+import com.trendreport.external.dto.TrendReportForm;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TrendServiceTest {
+
+    @InjectMocks
+    private TrendService trendService;
+
+
+    @Test
+    void createTrendDto_date() {
+        //given
+        TrendReportForm form = TrendReportForm.builder()
+            .timeUnit("date")
+            .keywordGroups(new ArrayList<>())
+            .build();
+        String startDate = LocalDateTime.now().minusDays(7)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        //when
+        TrendDto trendDto = trendService.createTrendDto(form);
+
+        //then
+        assertEquals(startDate,trendDto.getStartDate());
+    }
+    @Test
+    void createTrendDto_week() {
+        //given
+        TrendReportForm form = TrendReportForm.builder()
+            .timeUnit("week")
+            .keywordGroups(new ArrayList<>())
+            .build();
+        String startDate = LocalDateTime.now().minusWeeks(4)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        //when
+        TrendDto trendDto = trendService.createTrendDto(form);
+
+        //then
+        assertEquals(startDate,trendDto.getStartDate());
+    }
+    @Test
+    void createTrendDto_month() {
+        //given
+        TrendReportForm form = TrendReportForm.builder()
+            .timeUnit("month")
+            .keywordGroups(new ArrayList<>())
+            .build();
+        String startDate = LocalDateTime.now().minusMonths(12)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        //when
+        TrendDto trendDto = trendService.createTrendDto(form);
+
+        //then
+        assertEquals(startDate,trendDto.getStartDate());
+    }
+}

--- a/external/src/test/java/com/trendreport/external/service/TrendServiceTest.java
+++ b/external/src/test/java/com/trendreport/external/service/TrendServiceTest.java
@@ -2,6 +2,7 @@ package com.trendreport.external.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.trendreport.external.dto.TimeUnit;
 import com.trendreport.external.dto.TrendDto;
 import com.trendreport.external.dto.TrendReportForm;
 import java.time.LocalDateTime;
@@ -23,7 +24,7 @@ class TrendServiceTest {
     void createTrendDto_date() {
         //given
         TrendReportForm form = TrendReportForm.builder()
-            .timeUnit("date")
+            .timeUnit(TimeUnit.date)
             .keywordGroups(new ArrayList<>())
             .build();
         String startDate = LocalDateTime.now().minusDays(7)
@@ -39,7 +40,7 @@ class TrendServiceTest {
     void createTrendDto_week() {
         //given
         TrendReportForm form = TrendReportForm.builder()
-            .timeUnit("week")
+            .timeUnit(TimeUnit.week)
             .keywordGroups(new ArrayList<>())
             .build();
         String startDate = LocalDateTime.now().minusWeeks(4)
@@ -55,7 +56,7 @@ class TrendServiceTest {
     void createTrendDto_month() {
         //given
         TrendReportForm form = TrendReportForm.builder()
-            .timeUnit("month")
+            .timeUnit(TimeUnit.month)
             .keywordGroups(new ArrayList<>())
             .build();
         String startDate = LocalDateTime.now().minusMonths(12)

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -5,17 +5,7 @@ version = '0.0.1-SNAPSHOT'
 
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'org.springframework.data:spring-data-envers'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
-
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -28,3 +28,5 @@ springdoc:
   writer-with-default-pretty-printer: true
   model-and-view-allowed: true
   paths-to-match:
+server:
+  port: 8080


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> 외부 API를 멀티 모률로 구현

> WebClient를 활용하여 외부 API인 네이버 통합검색어 트랜드 조회 구현

> 테스트 코드 구현

## 💬리뷰 요구사항

> dto가 많아지면서 잘 관리하고 싶은데 어떤 방법이 있을까요? 혹은 dto의 명명이 이상하진 않은가요?

> TrendService의 메소드 명을 잘 짓고 싶은데 현재의 메소드 명이 명확한가요?

> webClient를 활용하여 외부 API통신을 구현해봤는데 현재 프로젝트에서 멀티 모듈로 외부 API통신하는 부분과 사용자 통신 하는 부분이 나뉘어져 있습니다. 이때, 외부 API통신하는 모듈과 사용자 통신하는 모듈 사이에 통신도 webclient를 사용해서 구현해도 괜찮을까요? 아님 websocket과 같은 기술을 사용하는 것을 추천하시나요?